### PR TITLE
[spring16_tamagotchi] Claude 토큰 사용량 기반 다마고치 성장 시스템 구현

### DIFF
--- a/16th_tech-ground/.idea/.gitignore
+++ b/16th_tech-ground/.idea/.gitignore
@@ -1,0 +1,10 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Environment-dependent path to Maven home directory
+/mavenHomeManager.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/16th_tech-ground/.idea/16th_tech-ground.iml
+++ b/16th_tech-ground/.idea/16th_tech-ground.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/16th_tech-ground/.idea/compiler.xml
+++ b/16th_tech-ground/.idea/compiler.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="CompilerConfiguration">
+    <annotationProcessing>
+      <profile name="Gradle Imported" enabled="true">
+        <outputRelativeToContentRoot value="true" />
+        <processorPath useClasspath="false">
+          <entry name="$USER_HOME$/.gradle/caches/modules-2/files-2.1/org.projectlombok/lombok/1.18.46/a5cfe99fdf320e84955ef653f2ce1bf789d11385/lombok-1.18.46.jar" />
+        </processorPath>
+        <module name="tamagotchi.test" />
+        <module name="tamagotchi.main" />
+      </profile>
+    </annotationProcessing>
+  </component>
+  <component name="JavacSettings">
+    <option name="ADDITIONAL_OPTIONS_OVERRIDE">
+      <module name="tamagotchi" options="-parameters" />
+      <module name="tamagotchi.main" options="-parameters" />
+      <module name="tamagotchi.test" options="-parameters" />
+    </option>
+  </component>
+</project>

--- a/16th_tech-ground/.idea/gradle.xml
+++ b/16th_tech-ground/.idea/gradle.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="GradleSettings">
+    <option name="linkedExternalProjectsSettings">
+      <GradleProjectSettings>
+        <option name="externalProjectPath" value="$PROJECT_DIR$/tamagotchi" />
+        <option name="gradleJvm" value="temurin-24" />
+        <option name="modules">
+          <set>
+            <option value="$PROJECT_DIR$/tamagotchi" />
+          </set>
+        </option>
+      </GradleProjectSettings>
+    </option>
+  </component>
+</project>

--- a/16th_tech-ground/.idea/misc.xml
+++ b/16th_tech-ground/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalStorageConfigurationManager" enabled="true" />
+  <component name="ProjectRootManager">
+    <output url="file://$PROJECT_DIR$/out" />
+  </component>
+</project>

--- a/16th_tech-ground/.idea/modules.xml
+++ b/16th_tech-ground/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/16th_tech-ground.iml" filepath="$PROJECT_DIR$/.idea/16th_tech-ground.iml" />
+    </modules>
+  </component>
+</project>

--- a/16th_tech-ground/.idea/vcs.xml
+++ b/16th_tech-ground/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
+  </component>
+</project>

--- a/16th_tech-ground/tamagotchi/CLAUDE.md
+++ b/16th_tech-ground/tamagotchi/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Claude API 토큰 사용량을 통해 다마고치를 키우는 토이 프로젝트. 사용자가 Claude를 사용할수록 토큰이 쌓이고, 그 토큰량에 따라 다마고치가 성장하는 구조를 목표로 한다.
+
+Spring Boot 4.0.6, Java 21, Gradle, MySQL 8 (prod) / H2 (test), Thymeleaf 서버사이드 렌더링. Mashup Spring 16 Team A 제작.
+
+## Commands
+
+Run from the `tamagotchi/` directory.
+
+```bash
+# Build
+./gradlew build
+
+# Run locally (http://localhost:8080/login)
+./gradlew bootRun
+
+# Run all tests (uses H2 in-memory DB)
+./gradlew test
+
+# Run a single test class
+./gradlew test --tests "mashup.spring16.tamagotchi.service.MemberServiceTest"
+
+# Start MySQL for local development
+cd docker && docker-compose up -d
+```
+
+Local dev connects to MySQL at `localhost:3306` with database `app_db`, user `app_user`, password `app_pass` (see `docker/docker-compose.yml`).
+
+Production requires env vars: `DB_URL`, `DB_USERNAME`, `DB_PASSWORD` (activate with `-Dspring.profiles.active=prod`).
+
+## Architecture
+
+Standard Spring MVC layered architecture: Controller → Service → Repository → JPA Entity.
+
+**User flow:**
+1. `/login` or `/signup` — auth handled by `AuthController`, password stored via BCrypt (`spring-security-crypto`, no full Spring Security filter chain)
+2. `/signup/select` — new users pick a pet character and name; stored as a `Tamagotchi` entity linked 1:1 to `Member`
+3. `/tamagotchi` — main room; redirects to `/login` if session missing, `/signup/select` if no pet exists
+
+**Session:** `memberId` (Long) stored in `HttpSession` — no JWT or cookie-based auth.
+
+**Key package:** `mashup.spring16.tamagotchi`
+- `domain/` — JPA entities (`Member`, `Tamagotchi`)
+- `dto/` — Java records for request binding (`LoginRequest`, `SignupRequest`, `TamagotchiCreateRequest`)
+- `service/` — business logic; unit-tested with H2
+- `controller/` — thin Thymeleaf controllers; redirect/forward model attributes
+- `config/AppConfig.java` — beans (e.g., `BCryptPasswordEncoder`)
+
+**Test profile:** `src/test/resources/application.properties` enables H2 with `ddl-auto=create-drop`. Tests are `@SpringBootTest` + `@Transactional`.

--- a/16th_tech-ground/tamagotchi/scripts/hook_feed.py
+++ b/16th_tech-ground/tamagotchi/scripts/hook_feed.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Claude Code Stop 훅 — 대화가 끝날 때 토큰 사용량을 다마고치 앱으로 전송합니다.
+
+설정 방법 (~/.claude/settings.json):
+{
+  "hooks": {
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "TAMAGOTCHI_API_TOKEN=<your-token> python3 /path/to/hook_feed.py"
+      }]
+    }]
+  }
+}
+"""
+
+import json
+import os
+import sys
+import urllib.request
+import urllib.error
+
+TAMAGOTCHI_URL = os.environ.get("TAMAGOTCHI_URL", "http://localhost:8080/api/tokens")
+
+
+def read_usage_from_transcript(transcript_path: str) -> tuple[int, int]:
+    input_tokens, output_tokens = 0, 0
+    try:
+        with open(transcript_path, "r") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                    # 직접 usage 필드 or message.usage 필드 탐색
+                    usage = entry.get("usage") or entry.get("message", {}).get("usage", {})
+                    if usage:
+                        input_tokens += usage.get("input_tokens", 0)
+                        output_tokens += usage.get("output_tokens", 0)
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+    except (OSError, IOError):
+        pass
+    return input_tokens, output_tokens
+
+
+def main():
+    api_token = os.environ.get("TAMAGOTCHI_API_TOKEN", "")
+    if not api_token:
+        sys.exit(0)
+
+    # Claude Code Stop 훅은 stdin으로 세션 정보를 전달
+    payload_data = {}
+    try:
+        raw = sys.stdin.read()
+        if raw.strip():
+            payload_data = json.loads(raw)
+    except (json.JSONDecodeError, OSError):
+        pass
+
+    transcript_path = payload_data.get("transcript_path", "")
+    input_tokens, output_tokens = read_usage_from_transcript(transcript_path)
+
+    # transcript에서 토큰을 읽지 못한 경우 대화 1회분 기본값 적용
+    if input_tokens == 0 and output_tokens == 0:
+        output_tokens = 1000
+
+    body = json.dumps({
+        "apiToken": api_token,
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
+    }).encode("utf-8")
+
+    try:
+        req = urllib.request.Request(
+            TAMAGOTCHI_URL,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        urllib.request.urlopen(req, timeout=3)
+    except (urllib.error.URLError, OSError):
+        pass  # 앱이 꺼져 있으면 조용히 skip
+
+
+if __name__ == "__main__":
+    main()

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/controller/TamagotchiController.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/controller/TamagotchiController.java
@@ -2,7 +2,9 @@ package mashup.spring16.tamagotchi.controller;
 
 import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+import mashup.spring16.tamagotchi.domain.Member;
 import mashup.spring16.tamagotchi.domain.Tamagotchi;
+import mashup.spring16.tamagotchi.repository.MemberRepository;
 import mashup.spring16.tamagotchi.repository.TamagotchiRepository;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -15,6 +17,7 @@ import java.util.Optional;
 public class TamagotchiController {
 
     private final TamagotchiRepository tamagotchiRepository;
+    private final MemberRepository memberRepository;
 
     @GetMapping("/tamagotchi")
     public String tamagotchi(HttpSession session, Model model) {
@@ -25,12 +28,20 @@ public class TamagotchiController {
 
         Optional<Tamagotchi> tamagotchi = tamagotchiRepository.findByMemberId(memberId);
         if (tamagotchi.isEmpty()) {
-            // 다마고치 없는 경우 캐릭터 선택으로 이동 (session의 memberId는 유지)
             return "redirect:/signup/select";
         }
 
-        model.addAttribute("character", tamagotchi.get().getCharacter());
-        model.addAttribute("petName", tamagotchi.get().getName());
+        Tamagotchi pet = tamagotchi.get();
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalStateException("회원을 찾을 수 없습니다."));
+
+        model.addAttribute("character", pet.getCharacter());
+        model.addAttribute("petName", pet.getName());
+        model.addAttribute("level", pet.getLevel());
+        model.addAttribute("hunger", pet.computeCurrentHunger());
+        model.addAttribute("experience", pet.getExperience());
+        model.addAttribute("expForNextLevel", pet.expForNextLevel());
+        model.addAttribute("apiToken", member.getApiToken());
         return "tamagotchi";
     }
 }

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/controller/TokenFeedController.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/controller/TokenFeedController.java
@@ -1,0 +1,28 @@
+package mashup.spring16.tamagotchi.controller;
+
+import lombok.RequiredArgsConstructor;
+import mashup.spring16.tamagotchi.dto.TokenFeedRequest;
+import mashup.spring16.tamagotchi.service.TamagotchiService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class TokenFeedController {
+
+    private final TamagotchiService tamagotchiService;
+
+    @PostMapping("/tokens")
+    public ResponseEntity<Void> feed(@RequestBody TokenFeedRequest request) {
+        try {
+            tamagotchiService.feed(request.apiToken(), request.inputTokens(), request.outputTokens());
+            return ResponseEntity.ok().build();
+        } catch (IllegalArgumentException e) {
+            return ResponseEntity.badRequest().build();
+        }
+    }
+}

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/domain/Member.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/domain/Member.java
@@ -7,6 +7,8 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.util.UUID;
+
 @Entity
 @Table(name = "member")
 @Getter
@@ -25,4 +27,14 @@ public class Member {
     @NonNull
     @Column(nullable = false)
     private String password;
+
+    @Column(name = "api_token", unique = true, nullable = false)
+    private String apiToken;
+
+    @PrePersist
+    private void generateApiToken() {
+        if (apiToken == null) {
+            apiToken = UUID.randomUUID().toString();
+        }
+    }
 }

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/domain/Tamagotchi.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/domain/Tamagotchi.java
@@ -7,12 +7,17 @@ import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+
 @Entity
 @Table(name = "tamagotchi")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @RequiredArgsConstructor
 public class Tamagotchi {
+
+    private static final long[] LEVEL_THRESHOLDS = {100, 500, 2000, 10000, 50000, 200000, 500000, 1000000, 5000000};
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -30,4 +35,46 @@ public class Tamagotchi {
     @NonNull
     @Column(nullable = false)
     private String name;
+
+    @Column(nullable = false)
+    private int level = 1;
+
+    @Column(nullable = false)
+    private int hunger = 100;
+
+    @Column(nullable = false)
+    private long experience = 0;
+
+    @Column
+    private LocalDateTime lastActiveAt;
+
+    public void feed(long inputTokens, long outputTokens) {
+        if (lastActiveAt != null) {
+            long hours = ChronoUnit.HOURS.between(lastActiveAt, LocalDateTime.now());
+            this.hunger = (int) Math.max(0, hunger - hours * 10L);
+        }
+        int hungerGain = (int) (inputTokens / 2000 + outputTokens / 200);
+        this.hunger = Math.min(100, this.hunger + hungerGain);
+        this.experience += inputTokens / 1000 + outputTokens / 100;
+        this.lastActiveAt = LocalDateTime.now();
+        checkLevelUp();
+    }
+
+    // 조회 시 DB에 저장하지 않고 현재 허기를 계산
+    public int computeCurrentHunger() {
+        if (lastActiveAt == null) return hunger;
+        long hours = ChronoUnit.HOURS.between(lastActiveAt, LocalDateTime.now());
+        return (int) Math.max(0, hunger - hours * 10L);
+    }
+
+    public long expForNextLevel() {
+        if (level >= 10) return experience;
+        return LEVEL_THRESHOLDS[level - 1];
+    }
+
+    private void checkLevelUp() {
+        while (level < 10 && experience >= LEVEL_THRESHOLDS[level - 1]) {
+            level++;
+        }
+    }
 }

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/dto/TokenFeedRequest.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/dto/TokenFeedRequest.java
@@ -1,0 +1,4 @@
+package mashup.spring16.tamagotchi.dto;
+
+public record TokenFeedRequest(String apiToken, long inputTokens, long outputTokens) {
+}

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/repository/MemberRepository.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/repository/MemberRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByUsername(String username);
+    Optional<Member> findByApiToken(String apiToken);
 }

--- a/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/service/TamagotchiService.java
+++ b/16th_tech-ground/tamagotchi/src/main/java/mashup/spring16/tamagotchi/service/TamagotchiService.java
@@ -22,4 +22,13 @@ public class TamagotchiService {
                 .orElseThrow(() -> new IllegalArgumentException("회원을 찾을 수 없습니다."));
         return tamagotchiRepository.save(new Tamagotchi(member, request.character(), request.name()));
     }
+
+    @Transactional
+    public void feed(String apiToken, long inputTokens, long outputTokens) {
+        Member member = memberRepository.findByApiToken(apiToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 API 토큰입니다."));
+        Tamagotchi tamagotchi = tamagotchiRepository.findByMemberId(member.getId())
+                .orElseThrow(() -> new IllegalArgumentException("다마고치를 찾을 수 없습니다."));
+        tamagotchi.feed(inputTokens, outputTokens);
+    }
 }

--- a/16th_tech-ground/tamagotchi/src/main/resources/static/css/tamagotchi.css
+++ b/16th_tech-ground/tamagotchi/src/main/resources/static/css/tamagotchi.css
@@ -51,6 +51,50 @@ body {
     object-fit: contain;
 }
 
+.hungry-bubble {
+    position: absolute;
+    top: -44px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #fff;
+    border: 2px solid #f44336;
+    border-radius: 20px;
+    padding: 6px 16px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #f44336;
+    white-space: nowrap;
+    box-shadow: 0 2px 8px rgba(244, 67, 54, 0.2);
+    animation: bounce 1s ease-in-out infinite;
+}
+
+.hungry-bubble::after {
+    content: '';
+    position: absolute;
+    bottom: -10px;
+    left: 50%;
+    transform: translateX(-50%);
+    border: 5px solid transparent;
+    border-top-color: #f44336;
+}
+
+@keyframes bounce {
+    0%, 100% { transform: translateX(-50%) translateY(0); }
+    50%       { transform: translateX(-50%) translateY(-5px); }
+}
+
+.pet-img.sad {
+    filter: grayscale(60%) brightness(0.85);
+    transform: rotate(-8deg);
+    transform-origin: bottom center;
+    animation: droop 2s ease-in-out infinite;
+}
+
+@keyframes droop {
+    0%, 100% { transform: rotate(-8deg); }
+    50%       { transform: rotate(-5deg); }
+}
+
 .pet-name {
     display: inline-block;
     background: rgba(255, 255, 255, 0.88);
@@ -62,4 +106,132 @@ body {
     color: #555;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
     white-space: nowrap;
+}
+
+/* 스탯 패널 */
+.stats-panel {
+    position: absolute;
+    top: 16px;
+    left: 16px;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(6px);
+    border-radius: 14px;
+    padding: 12px 16px;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 200px;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.12);
+}
+
+.stat-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.stat-label {
+    font-size: 12px;
+    font-weight: 700;
+    color: #888;
+    width: 28px;
+    flex-shrink: 0;
+}
+
+.stat-value {
+    font-size: 11px;
+    color: #666;
+    white-space: nowrap;
+}
+
+.level-badge {
+    background: #7c6af7;
+    color: #fff;
+    border-radius: 8px;
+    padding: 2px 10px;
+    font-size: 13px;
+    font-weight: 700;
+}
+
+.bar-wrap {
+    flex: 1;
+    height: 10px;
+    background: #e0e0e0;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.bar {
+    height: 100%;
+    border-radius: 6px;
+    transition: width 0.4s ease;
+}
+
+.hunger-bar.full { background: #4caf50; }
+.hunger-bar.mid  { background: #ffc107; }
+.hunger-bar.low  { background: #f44336; }
+.exp-bar         { background: #7c6af7; }
+
+/* 훅 설정 버튼 */
+.hook-btn {
+    position: absolute;
+    top: 16px;
+    right: 16px;
+    z-index: 10;
+    background: rgba(255, 255, 255, 0.85);
+    backdrop-filter: blur(6px);
+    border: none;
+    border-radius: 10px;
+    padding: 8px 14px;
+    font-size: 13px;
+    font-weight: 700;
+    color: #555;
+    cursor: pointer;
+    box-shadow: 0 2px 8px rgba(0,0,0,0.12);
+}
+
+.hook-btn:hover { background: rgba(255,255,255,0.97); }
+
+/* 훅 설정 모달 */
+.hook-modal {
+    position: absolute;
+    top: 56px;
+    right: 16px;
+    z-index: 20;
+    background: rgba(255, 255, 255, 0.97);
+    border-radius: 14px;
+    padding: 16px;
+    max-width: 420px;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.18);
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    font-size: 13px;
+    color: #444;
+}
+
+.hook-modal.hidden { display: none; }
+
+.api-token {
+    display: block;
+    background: #f3f0ff;
+    border-radius: 8px;
+    padding: 8px 12px;
+    font-size: 12px;
+    color: #5a4fcf;
+    word-break: break-all;
+    user-select: all;
+}
+
+.hook-config {
+    background: #1e1e2e;
+    color: #cdd6f4;
+    border-radius: 8px;
+    padding: 12px;
+    font-size: 11px;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre-wrap;
+    word-break: break-all;
 }

--- a/16th_tech-ground/tamagotchi/src/main/resources/templates/tamagotchi.html
+++ b/16th_tech-ground/tamagotchi/src/main/resources/templates/tamagotchi.html
@@ -8,11 +8,56 @@
 <body>
     <div class="room">
         <img class="room-bg" th:src="@{/images/room/{file}(file='tamagotchi_device.png')}" alt="다마고치 방">
+
         <div class="pet-area" th:if="${character}">
+            <div class="hungry-bubble" th:if="${hunger == 0}">배고파요 😢</div>
             <p class="pet-name" th:text="${petName}"></p>
             <img class="pet-img"
+                 th:classappend="${hunger == 0} ? ' sad' : ''"
                  th:src="|/images/pet/${character}.png|"
                  th:alt="${petName}">
+        </div>
+
+        <div class="stats-panel">
+            <div class="stat-row">
+                <span class="stat-label">Lv.</span>
+                <span class="level-badge" th:text="${level}"></span>
+            </div>
+            <div class="stat-row">
+                <span class="stat-label">허기</span>
+                <div class="bar-wrap">
+                    <div class="bar hunger-bar"
+                         th:classappend="${hunger >= 60} ? ' full' : (${hunger >= 30} ? ' mid' : ' low')"
+                         th:style="'width:' + ${hunger} + '%'"></div>
+                </div>
+                <span class="stat-value" th:text="${hunger} + '/100'"></span>
+            </div>
+            <div class="stat-row">
+                <span class="stat-label">EXP</span>
+                <div class="bar-wrap">
+                    <div class="bar exp-bar"
+                         th:style="${expForNextLevel > 0} ? 'width:' + (${experience * 100 / expForNextLevel}) + '%' : 'width:100%'"></div>
+                </div>
+                <span class="stat-value" th:text="${experience} + '/' + ${expForNextLevel}"></span>
+            </div>
+        </div>
+
+        <button class="hook-btn" onclick="document.getElementById('hook-modal').classList.toggle('hidden')">⚙ 훅 설정</button>
+        <div id="hook-modal" class="hook-modal hidden">
+            <p><b>1.</b> 아래 API 토큰을 복사하세요</p>
+            <code class="api-token" th:text="${apiToken}"></code>
+            <p><b>2.</b> <code>~/.claude/settings.json</code> 에 추가</p>
+            <pre class="hook-config">{
+  "hooks": {
+    "Stop": [{
+      "matcher": "",
+      "hooks": [{
+        "type": "command",
+        "command": "<span th:text="'TAMAGOTCHI_API_TOKEN=' + ${apiToken} + ' python3 /Users/yeonkyungryu/study/mashup-study/S3A/16th_tech-ground/tamagotchi/scripts/hook_feed.py'"></span>"
+      }]
+    }]
+  }
+}</pre>
         </div>
     </div>
 </body>


### PR DESCRIPTION
## 구현 내용

Claude Code 사용 시 발생하는 토큰을 실시간으로 집계해 다마고치를 키우는 시스템을 구현했습니다.

### 핵심 흐름
```
Claude Code 대화 종료 → Stop 훅 실행 → 토큰 집계 → POST /api/tokens → 펫 스탯 업데이트
```

### 변경 사항

**도메인**
- `Member`: `apiToken` 필드 추가 (회원가입 시 UUID 자동 발급, 훅 인증에 사용)
- `Tamagotchi`: `level`, `hunger`, `experience`, `lastActiveAt` 필드 추가
  - `feed()`: 토큰 입력 시 허기 회복 + EXP 증가 + 레벨업 처리
  - `computeCurrentHunger()`: 마지막 활동 이후 경과 시간 기반 허기 자동 감소 (1시간당 -10)

**게임 공식**
- 허기: output 200토큰 → +1 (최대 100), 1시간 미사용 → -10
- EXP: output 100토큰 → +1
- 레벨업 기준: 100 / 500 / 2,000 / 10,000 / 50,000 / ... (누적 EXP)

**API**
- `POST /api/tokens`: apiToken + 토큰 수신 → 펫 스탯 반영

**UI**
- 좌상단 스탯 패널: 레벨 뱃지, 허기 바(초록/노랑/빨강), EXP 바
- 우상단 훅 설정 버튼: 클릭 시 apiToken과 `settings.json` 설정 코드 표시
- 허기 0 상태: 펫 이미지 흑백+기울어짐, "배고파요 😢" 말풍선 애니메이션

**Claude Code 훅**
- `scripts/hook_feed.py`: Stop 훅으로 실행, transcript JSONL에서 토큰 집계 후 앱으로 전송

## Test plan
- [ ] 회원가입 후 apiToken 발급 확인
- [ ] 훅 설정 후 Claude Code 대화 → 허기/EXP 증가 확인
- [ ] 허기 0 설정 후 슬픈 펫 UI 확인
